### PR TITLE
Fix the look of "fl" in text

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'Panton';
   src: url('/assets/fonts/panton.woff2') format('woff2');
+  font-feature-settings: "liga" 0;
   font-weight: normal;
   font-style: normal;
   font-display: swap;


### PR DESCRIPTION
# Summary
While checking out the page, I noticed that the `fl` letters combo renders wanky. This PR disables the ligatures to prevent that.

# Experiment motivating the change
Without the change:
<img width="3838" height="1980" alt="image" src="https://github.com/user-attachments/assets/d656981f-bb00-4d11-8833-6dd32659588a" />
With the change:
<img width="3865" height="1986" alt="image" src="https://github.com/user-attachments/assets/29b3cba1-34db-4d34-b844-3cc49448fad3" />

# Disclaimer
I did not review the entire page to look for regressions, but based on FontDrop, the only two ligatures are `fl` and `fi`, and neither will look good.
